### PR TITLE
Complete Spec of Unparse Function

### DIFF
--- a/src/lens_odm_parser/core.clj
+++ b/src/lens_odm_parser/core.clj
@@ -803,8 +803,15 @@
     (map unparse-subject-data)
     subject-data))
 
+(s/def :xml/sexp
+  (s/spec (s/cat :tag keyword?
+                 :attr (s/? (s/map-of keyword? any?))
+                 :content (s/* (s/alt :sexpr :xml/sexp
+                                      :text any?)))))
+
 (s/fdef unparse-file
-  :args (s/cat :file :odm/file))
+  :args (s/cat :file :odm/file)
+  :ret :xml/sexp)
 
 (defn unparse-file
   [{:keys [odm.file/clinical-data] :as file}]

--- a/test/lens_odm_parser/core_test.clj
+++ b/test/lens_odm_parser/core_test.clj
@@ -308,12 +308,18 @@
       [::file/clinical-data 0 ::clinical-data/study-oid] := "S01")))
 
 (deftest unparse-file-test
-  (given
-    (second
-      (unparse-file
-        {::file/oid "FI01"
-         ::file/type :snapshot
-         ::file/creation-date-time #inst "2016-03-18T14:41:00.000-00:00"}))
-    :FileType := "Snapshot"
-    :FileOID := "FI01"
-    :CreationDateTime := "2016-03-18T14:41:00.000Z"))
+  (testing "Concrete example"
+    (given
+      (second
+        (unparse-file
+          {::file/oid "FI01"
+           ::file/type :snapshot
+           ::file/creation-date-time #inst "2016-03-18T14:41:00.000-00:00"}))
+      :FileType := "Snapshot"
+      :FileOID := "FI01"
+      :CreationDateTime := "2016-03-18T14:41:00.000Z"))
+
+  (testing "Spec check"
+    (is
+      (->> (st/check `unparse-file)
+           (every? #(get-in % [:clojure.spec.test.check/ret :result]))))))


### PR DESCRIPTION
Within the spec of the `unparse-file` function the return value was missing. This PR adds the missing part.